### PR TITLE
adding dev mode: auto for pkgdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: discrim
 Title: Model Wrappers for Discriminant Analysis
-Version: 0.2.0.9000
+Version: 0.2.0
 Authors@R: 
     c(person(given = "Max",
              family = "Kuhn",

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -10,6 +10,9 @@ template:
       in_header: |
         <script defer data-domain="discrim.tidymodels.org,all.tidymodels.org" src="https://plausible.io/js/plausible.js"></script>
 
+development:
+  mode: auto
+
 figures:
   fig.width: 8
   fig.height: 5.75

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,6 +4,7 @@ template:
   package: tidytemplate
   bootstrap: 5
   bslib:
+    danger: "#CA225E"
     primary: "#CA225E"
 
   includes:


### PR DESCRIPTION
The pkgdown site currently shows `0.2.0.9000` as the release version and `0.1.3.9000` as the development version. Should we try some git magic or let the auto dev mode sort that out with the next release? The content of the release site should identical with that of the release `0.2.0` because it only *just* happened. (And the content of the dev version gets updated with the next PR, no?)