### PR TITLE
switch back to dev version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: discrim
 Title: Model Wrappers for Discriminant Analysis
-Version: 0.2.0
+Version: 0.2.0.9000
 Authors@R: 
     c(person(given = "Max",
              family = "Kuhn",


### PR DESCRIPTION
in #46, we temporarily switched to the release version to trigger a rebuild of the pkgdown site with `dev mode: auto` and this PR switches the version back to the dev version