### PR TITLE
allow discrim_linear() to specify the prior probability of each class

### DIFF
--- a/R/discrim_linear_data.R
+++ b/R/discrim_linear_data.R
@@ -22,7 +22,9 @@ make_discrim_linear_MASS <- function() {
       interface = "formula",
       protect = c("formula", "data"),
       func = c(pkg = "MASS", fun = "lda"),
-      defaults = list()
+      defaults = list(
+        prior = NULL
+      )
     )
   )
 
@@ -291,7 +293,9 @@ make_discrim_linear_sparsediscrim <- function() {
       interface = "data.frame",
       protect = c("x", "y"),
       func = c(pkg = "discrim", fun = "fit_regularized_linear"),
-      defaults = list()
+      defaults = list(
+        prior = NULL
+      )
     )
   )
 


### PR DESCRIPTION
For LDA using the MASS and sparsediscrim engines, the base modelling functions have a `prior` argument.

It would be useful if this could be specified in `discrim`/`tidymodels`.

This PR just adds `prior = NULL` as engine `defaults` for these two engines.

I am not sure if this is the most sensible way to do this. Prior probabilities aren't really tunable (well, shouldn't be?) so I don't think they fit as an argument? But it is a little awkward to use `set_engine("MASS", prior = c(1,1,1)/3)` prior to passing through to `fit()` when we haven't yet defined the outcome variable.

Am happy to adjust accordingly. Thanks for the great package(s)!

Simple way to test:

``` r
discrim_linear() %>%
  fit(Species ~ ., data=iris) %>%
  purrr::pluck("fit", "prior")

discrim_linear() %>%
  set_engine("MASS", prior=c(2,1,2)/5) %>%
  fit(Species ~ ., data=iris) %>%
  purrr::pluck("fit", "prior")
```

Side note: `lda()` uses `is.missing(prior)` to determine whether the prior was set. This seems to work when I specify `prior=NULL` in defaults, but it was unclear to me that it would work - happy to take pointers!
