### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,7 +8,6 @@ derby.log
 ^logs$
 ^tests/testthat/logs$
 ^revdep$
-^README\.md$
 ^README\.Rmd$
 ^docs$
 ^\.travis\.yml$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.