### PR TITLE
remove deprecated `default` arg for dials parameter objects

### DIFF
--- a/R/parameters.R
+++ b/R/parameters.R
@@ -26,7 +26,6 @@ frac_common_cov <- function(range = c(0, 1), trans = NULL) {
     range = range,
     inclusive = c(TRUE, TRUE),
     trans = trans,
-    default = 0.5,
     label = c(frac_common_cov = "Fraction of the Common Covariance Matrix"),
     finalize = NULL
   )
@@ -40,7 +39,6 @@ frac_identity <- function(range = c(0, 1), trans = NULL) {
     range = range,
     inclusive = c(TRUE, TRUE),
     trans = trans,
-    default = 0.5,
     label = c(frac_identity = "Fraction of the Identity Matrix"),
     finalize = NULL
   )


### PR DESCRIPTION
The next version of dials will deprecate the `default` argument to the constructors `dials::new_quant_param()` and `dials::new_qual_param()` so this PR removes usage of those arguments.

For more context: https://github.com/tidymodels/dials/pull/241